### PR TITLE
Feature/kafka

### DIFF
--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,20 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def test_produce():
+    response = client.get('/produce/test_message')
+    assert response.status_code == 200
+    assert json.loads(str(response.content, 'utf-8'))['content'] == 'succeed'
+    return json.loads(str(response.content, 'utf-8'))['content']
+
+
+def test_consume():
+    response = client.get('/consume')
+    assert response.status_code == 408
+    return json.loads(str(response.content, 'utf-8'))['content'] == 'error'


### PR DESCRIPTION
1. /main.py의 /consume api 오류처리 변경 및 추가하였습니다.
- 오류가 200번대 status code를 반환하도록 되어있어, 408번으로 변경하였습니다.
2. /test_main.py
- consume 테스트코드 추가하였습니다.